### PR TITLE
Fixing keys-list-tree inconsistency in Map_Discard()

### DIFF
--- a/src/Map.c
+++ b/src/Map.c
@@ -178,6 +178,7 @@ void Map_Discard(var self, var key) {
         node->leaf_val = inorder_val;
         
         discard(md->keys, key);
+        push_back(md->keys, inorder_key);
         return;
       }
           


### PR DESCRIPTION
For issue #79 